### PR TITLE
Increase GCP cloud build timeout to avoid flaky deployment

### DIFF
--- a/gcp/clouddeploy.yaml
+++ b/gcp/clouddeploy.yaml
@@ -7,4 +7,5 @@ steps:
   args: ['test']
 - name: "gcr.io/cloud-builders/gcloud"  
   args: ["app", "deploy"]
-  timeout: "600s"
+  timeout: 1800s
+timeout: 3000s


### PR DESCRIPTION
Several previous master deployment build has been failing due to timeout issue [1]. This PR increases the Cloud Build timeout from 10 mins to 30 mins which prevents deployment failure due to timeout. 

[1] https://screenshot.googleplex.com/oV4gYYGHiWH